### PR TITLE
Remove fixed width for proper viewing on smaller screens

### DIFF
--- a/src/_includes/partials/navbar.html
+++ b/src/_includes/partials/navbar.html
@@ -18,7 +18,7 @@
         </button>
 
         <!--Menu-->
-        <div class="lg:inline-flex md:justify-end justify-items-end lg:w-auto w-3/5 my-6"  :class="isOpen ? '': 'hidden'  ">
+        <div class="lg:inline-flex md:justify-end justify-items-end lg:w-auto my-6"  :class="isOpen ? '': 'hidden'  ">
             {% if navigation.items %}
 
                 <ul class="flex md:flex-row flex-shrink flex-col px-6 list-reset">


### PR DESCRIPTION
Some screens were forcing two lines for the navbar items and the logo before the break for small screens. Small screens were overflowing the navbar container. This fixes that. 